### PR TITLE
Upgrade Keycloak Js to 23.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,14 @@ keycloak-logs: ## Display logs
 
 keycloak-stop: ## Stop the project with docker.
 	$(DOCKER_COMPOSE) down
+
+DOCKER_COMPOSE_LEGACY = docker-compose -p ra-keycloak-legacy -f ./packages/demo/docker-compose-legacy.yml
+
+keycloak-start-legacy: ## Start the legacy project with docker.
+	$(DOCKER_COMPOSE_LEGACY) up --force-recreate -d
+
+keycloak-logs-legacy: ## Display logs for the legacy project
+	$(DOCKER_COMPOSE_LEGACY) logs -f
+
+keycloak-stop-legacy: ## Stop the legacy project with docker.
+	$(DOCKER_COMPOSE_LEGACY) down

--- a/packages/demo/docker-compose-legacy.yml
+++ b/packages/demo/docker-compose-legacy.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_PASSWORD: password
       
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:legacy
     environment:
       DB_VENDOR: POSTGRES
       DB_ADDR: postgres
@@ -26,12 +26,9 @@ services:
       DB_PASSWORD: password
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: password
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: password
       # Uncomment the line below if you want to specify JDBC parameters. The parameter below is just an example, and it shouldn't be used in production without knowledge. It is highly recommended that you read the PostgreSQL JDBC driver documentation in order to use it.
       #JDBC_PARAMS: "ssl=true"
     ports:
       - 8080:8080
     depends_on:
       - postgres
-    command: start-dev --http-relative-path /auth

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -15,7 +15,7 @@
         "@mui/icons-material": "^5.0.1",
         "@mui/material": "^5.0.2",
         "jsonexport": "^3.2.0",
-        "keycloak-js": "^19.0.2",
+        "keycloak-js": "^23.0.1",
         "lodash": "~4.17.5",
         "prop-types": "^15.7.2",
         "proxy-polyfill": "^0.3.0",

--- a/packages/ra-keycloak/package.json
+++ b/packages/ra-keycloak/package.json
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "jwt-decode": "^3.1.2",
-        "keycloak-js": "^19.0.2",
+        "keycloak-js": "^23.0.1",
         "react-admin": "^4.4.0"
     },
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5401,10 +5401,10 @@ jest@^29.1.1:
     import-local "^3.0.2"
     jest-cli "^29.1.2"
 
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
+js-sha256@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.10.1.tgz#b40104ba1368e823fdd5f41b66b104b15a0da60d"
+  integrity sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==
 
 js-sha3@0.8.0:
   version "0.8.0"
@@ -5522,13 +5522,19 @@ jwt-decode@^3.1.2:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
   integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
 
-keycloak-js@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-19.0.2.tgz#df8d12138c3edf70d9880097204a943674c605ee"
-  integrity sha512-tQjkLVVIwaV1xf4Fri5u+d+Ttddrh0S5cv3ltG+uTUd7WNwt5LkOXsPnqWQjj9stpoBTFgTuzIqJ2C6vk0CcEQ==
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
+keycloak-js@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-23.0.1.tgz#8e5591ad568a660ee608553260c79d73da832a05"
+  integrity sha512-n7bF7GGrxmzB6mveXYhVoKDZv96PEtrn89/2qSNSCreBKovW/bGcrB6WFBiUOzdWoRW03mDYcU8sUfvELiBPPw==
   dependencies:
     base64-js "^1.5.1"
-    js-sha256 "^0.9.0"
+    js-sha256 "^0.10.1"
+    jwt-decode "^4.0.0"
 
 kind-of@^6.0.2:
   version "6.0.3"


### PR DESCRIPTION
**Problem**

Keycloak 23.0.0 adds the parameter iss in the OAuth 2.0/OpenID Connect Authentication Response, and this change the response with the current Keycloak Js Adapter.
See https://www.keycloak.org/docs/latest/upgrading/index.html#added-iss-parameter-to-oauth-2-0openid-connect-authentication-response

This breaks the react router behavior as we always land on the `iss` route, which results in a blank page

**Solution**
Updating the Keycloak Js adapter fixes the issue.
The new adapter is backward compatible, so it works with both keycloak:legacy and keycloak:23.0.1

